### PR TITLE
CHECKOUT-2645: Fix callback getting called prematurely

### DIFF
--- a/src/form-poster.js
+++ b/src/form-poster.js
@@ -16,8 +16,8 @@ export default class FormPoster {
     postForm(url, data, callback = () => {}) {
         const form = this._formBuilder.build(url, data);
 
-        window.addEventListener('beforeunload', function handleBeforeUnload() {
-            window.removeEventListener('beforeunload', handleBeforeUnload);
+        window.addEventListener('unload', function handleUnload() {
+            window.removeEventListener('unload', handleUnload);
             callback();
         });
 

--- a/test/form-poster.spec.js
+++ b/test/form-poster.spec.js
@@ -40,7 +40,7 @@ describe('FormPoster', () => {
 
             const event = document.createEvent('Event');
 
-            event.initEvent('beforeunload', true, false);
+            event.initEvent('unload', true, false);
             document.body.dispatchEvent(event);
 
             expect(callback).toHaveBeenCalled();


### PR DESCRIPTION
## What?
* Listen to `unload` instead of `beforeunload` event.

## Why?
* We want to listen to the very last event before navigating away. `beforeunload` happens before `unload` event. So we should listen to that instead.

## Testing / Proof
* Unit

ping @bigcommerce-labs/checkout 
