### PR TITLE
feat(payment): PAYPAL-3453 Deleted the line with deleting an element from the DOM

### DIFF
--- a/src/form-poster.ts
+++ b/src/form-poster.ts
@@ -25,7 +25,6 @@ export default class FormPoster {
         // In order to submit the form, the form must be attached to DOM.
         document.body.appendChild(form);
         form.submit();
-        document.body.removeChild(form);
     }
 
     private _prependHost(url: string): string {


### PR DESCRIPTION
## What?

Removed previous logic for deleting a form element to preventing error of form submitting.

## Why?

Some stores do not redirect to the checkout page after making a purchase using the Braintree wallet button because of

<img width="524" alt="Screenshot 2024-02-01 at 18 08 42" src="https://github.com/bigcommerce/form-poster-js/assets/99336044/8a22c8bc-8933-4409-8a89-eac9874adbd6">

The warning "Form submission canceled because the form is not connected" occurs when you remove the form from the page while the browser **is still processing the submission event** or you try to submit a form that is not attached to the document.

This problem can also occur for other payment methods that use FormPoster. 
If we want to remove an `form` from the document after the query is complete, we need to write the logic in a different way.

A request with the current implementation `form.submit(); document.body.removeChild(form)` cannot be executed because the form may be removed while the request is being executed. As a result, we see the warning and do not see the request on the Network tab in the developer dashboard.

I am pretty sure that we do not need this line with removing form element at all. In this case, we avoid possible problems with other stores where this problem may appear

## Testing / Proof

Before

https://github.com/bigcommerce/form-poster-js/assets/99336044/0071c27a-0c43-4ffe-8563-86f3da8e0380


After

Important compiled code was rewritten using Resource Override to show that redirection works with the removal of the form element from the document

https://github.com/bigcommerce/form-poster-js/assets/99336044/a8eb61a8-0832-4876-bd06-87b3328c4429


ping @bigcommerce/frontend
